### PR TITLE
fix(list): don't set buffer name

### DIFF
--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -216,7 +216,6 @@ local function get_lsp_method_label(method_name)
 end
 
 function List:setup(opts)
-  vim.api.nvim_buf_set_name(self.bufnr, 'Glance')
   utils.win_set_options(self.winnr, win_opts)
   utils.buf_set_options(self.bufnr, buf_opts)
 


### PR DESCRIPTION
This is because the "buffer name" represents the file name of the buffer
- seeing as these are just ephemeral nofile buffers they don't represent
a file on the file system.

Closes #34.
